### PR TITLE
Add browser-based bid executor and wire it into CLI

### DIFF
--- a/src/avtor24_bot/__init__.py
+++ b/src/avtor24_bot/__init__.py
@@ -1,0 +1,11 @@
+"""Automation toolkit for Автора24 bidding bot."""
+
+from .browser_bid import BrowserBidExecutor, BidStatus, BrowserBidError
+from .worker import AccountWorker
+
+__all__ = [
+    "BrowserBidExecutor",
+    "BidStatus",
+    "BrowserBidError",
+    "AccountWorker",
+]

--- a/src/avtor24_bot/browser_bid.py
+++ b/src/avtor24_bot/browser_bid.py
@@ -1,0 +1,191 @@
+"""Browser-based bid submission helpers for Автора24."""
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optional
+
+from playwright.sync_api import Browser, BrowserContext, Error, Page, Playwright, sync_playwright
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BidStatus(str, Enum):
+    """Possible outcomes of the bid submission flow."""
+
+    SUCCESS = "success"
+    CAPTCHA_REQUIRED = "captcha_required"
+    MODAL_TIMEOUT = "modal_timeout"
+    FAILED = "failed"
+
+
+class BrowserBidError(RuntimeError):
+    """Raised when the browser cannot be initialised or the bid submission fails."""
+
+
+@dataclass(slots=True)
+class BrowserBidExecutor:
+    """High level API that encapsulates bid submission via a browser driver."""
+
+    base_url: str
+    cookies: Iterable[Mapping[str, object]]
+    profile_path: Path
+    browser_type: str = "chromium"
+    headless: bool = True
+    slow_mo: Optional[int] = None
+    playwright_factory: Callable[[], Any] = field(default=sync_playwright, repr=False)
+    _playwright_manager: Optional[Any] = field(default=None, init=False, repr=False)
+    _playwright: Optional[Playwright] = field(default=None, init=False, repr=False)
+    _browser: Optional[Browser] = field(default=None, init=False, repr=False)
+    _context: Optional[BrowserContext] = field(default=None, init=False, repr=False)
+
+    BID_INPUT_SELECTOR: str = "input[name='MakeOffer__inputBid']"
+    COMMENT_INPUT_SELECTOR: str = "textarea[name='makeOffer_comment']"
+    SUBMIT_BUTTON_SELECTOR: str = "button[data-testid='MakeOffer__submit']"
+    SUCCESS_MODAL_SELECTOR: str = "div[data-testid='make-offer-success']"
+    CAPTCHA_SELECTOR: str = "iframe[src*='captcha']"
+
+    def __post_init__(self) -> None:
+        self.profile_path = Path(self.profile_path)
+        self.profile_path.mkdir(parents=True, exist_ok=True)
+
+    # Public API -----------------------------------------------------------------
+    def place_bid(self, order: Mapping[str, object], bid: float, message: str) -> BidStatus:
+        """Submit a bid for the provided order."""
+
+        page = self._ensure_page()
+        order_id = self._extract_order_id(order)
+        LOGGER.debug("Opening order %s", order_id)
+        page.goto(self._order_url(order_id), wait_until="domcontentloaded")
+
+        try:
+            self._fill_bid_form(page, bid, message)
+            page.click(self.SUBMIT_BUTTON_SELECTOR)
+        except Error as exc:  # pragma: no cover - defensive branch
+            LOGGER.exception("Unable to submit bid: %s", exc)
+            return BidStatus.FAILED
+
+        status = self._wait_for_completion(page)
+        LOGGER.debug("Bid submission finished with status %s", status)
+        return status
+
+    def close(self) -> None:
+        """Tear down Playwright objects associated with the executor."""
+
+        LOGGER.debug("Closing BrowserBidExecutor for profile %s", self.profile_path)
+        with contextlib.suppress(Exception):
+            if self._context is not None:
+                self._context.close()
+        with contextlib.suppress(Exception):
+            if self._browser is not None:
+                self._browser.close()
+        self._context = None
+        self._browser = None
+
+        if self._playwright_manager is not None:
+            with contextlib.suppress(Exception):
+                self._playwright_manager.__exit__(None, None, None)
+        self._playwright_manager = None
+        self._playwright = None
+
+    # Internal helpers ------------------------------------------------------------
+    def _ensure_page(self) -> Page:
+        context = self._ensure_context()
+        LOGGER.debug("Creating a fresh page for bid submission")
+        return context.new_page()
+
+    def _ensure_context(self) -> BrowserContext:
+        if self._context is not None:
+            return self._context
+
+        browser = self._ensure_browser()
+        LOGGER.debug("Opening new browser context at %s", self.profile_path)
+        storage_state = self._build_storage_state(self.cookies)
+        self._context = browser.new_context(storage_state=storage_state)
+        return self._context
+
+    def _ensure_browser(self) -> Browser:
+        if self._browser is not None:
+            return self._browser
+
+        LOGGER.debug("Launching %s browser for profile %s", self.browser_type, self.profile_path)
+        manager = self.playwright_factory()
+        self._playwright_manager = manager
+        try:
+            playwright = manager.__enter__()
+        except Exception as exc:  # pragma: no cover - defensive branch
+            raise BrowserBidError("Unable to start Playwright") from exc
+        self._playwright = playwright
+
+        try:
+            browser_launcher = getattr(playwright, self.browser_type)
+        except AttributeError as exc:  # pragma: no cover - defensive branch
+            raise BrowserBidError(f"Unsupported browser type: {self.browser_type}") from exc
+
+        launch_kwargs = {"headless": self.headless}
+        if self.slow_mo is not None:
+            launch_kwargs["slow_mo"] = self.slow_mo
+
+        self._browser = browser_launcher.launch(**launch_kwargs)
+        return self._browser
+
+    def _build_storage_state(self, cookies: Iterable[Mapping[str, object]]) -> Mapping[str, List[MutableMapping[str, object]]]:
+        prepared: List[MutableMapping[str, object]] = []
+        for cookie in cookies:
+            normalised = dict(cookie)
+            normalised.setdefault("sameSite", "Lax")
+            prepared.append(normalised)
+        return {"cookies": prepared}
+
+    def _fill_bid_form(self, page: Page, bid: float, message: str) -> None:
+        LOGGER.debug("Filling bid form: bid=%s", bid)
+        page.fill(self.BID_INPUT_SELECTOR, str(bid))
+        page.fill(self.COMMENT_INPUT_SELECTOR, message)
+
+    def _wait_for_completion(self, page: Page, timeout: float = 15.0) -> BidStatus:
+        start = time.monotonic()
+        while time.monotonic() - start < timeout:
+            if self._is_captcha_visible(page):
+                return BidStatus.CAPTCHA_REQUIRED
+            if self._is_success_modal_visible(page):
+                return BidStatus.SUCCESS
+            time.sleep(0.25)
+        return BidStatus.MODAL_TIMEOUT
+
+    def _is_success_modal_visible(self, page: Page) -> bool:
+        with contextlib.suppress(Error):
+            modal = page.query_selector(self.SUCCESS_MODAL_SELECTOR)
+            if modal and modal.is_visible():
+                return True
+        return False
+
+    def _is_captcha_visible(self, page: Page) -> bool:
+        with contextlib.suppress(Error):
+            captcha = page.query_selector(self.CAPTCHA_SELECTOR)
+            if captcha and captcha.is_visible():
+                return True
+        return False
+
+    def _extract_order_id(self, order: Mapping[str, object]) -> str:
+        for key in ("id", "order_id"):
+            if key in order:
+                return str(order[key])
+        raise BrowserBidError("Order payload is missing an identifier")
+
+    def _order_url(self, order_id: str) -> str:
+        return f"{self.base_url.rstrip('/')}/order/{order_id}"
+
+    # Context manager protocol ----------------------------------------------------
+    def __enter__(self) -> "BrowserBidExecutor":
+        self._ensure_browser()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+__all__ = ["BrowserBidExecutor", "BidStatus", "BrowserBidError"]

--- a/src/avtor24_bot/cli.py
+++ b/src/avtor24_bot/cli.py
@@ -1,0 +1,125 @@
+"""Command line helpers for Автора24 bot."""
+from __future__ import annotations
+
+import argparse
+import atexit
+import contextlib
+import json
+import logging
+import signal
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Mapping, Sequence
+
+from .browser_bid import BrowserBidExecutor
+from .worker import AccountWorker, Scheduler
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_PROFILES_ROOT = Path(".avtor24/profiles")
+
+
+@dataclass
+class AccountConfig:
+    """Configuration describing how to authenticate an account."""
+
+    name: str
+    base_url: str
+    cookies: Sequence[Mapping[str, object]]
+
+
+def create_account_worker(
+    config: AccountConfig, scheduler: Scheduler, profiles_root: Path = DEFAULT_PROFILES_ROOT
+) -> AccountWorker:
+    """Instantiate :class:`AccountWorker` with a dedicated browser executor."""
+
+    profiles_root.mkdir(parents=True, exist_ok=True)
+    profile_path = profiles_root / config.name
+    executor = BrowserBidExecutor(
+        base_url=config.base_url,
+        cookies=config.cookies,
+        profile_path=profile_path,
+    )
+    worker = AccountWorker(scheduler=scheduler, bid_executor=executor)
+    atexit.register(worker.close)
+    return worker
+
+
+def load_cookies(path: Path) -> List[Mapping[str, object]]:
+    """Load cookies from a JSON file."""
+
+    LOGGER.debug("Loading cookies from %s", path)
+    with path.open("r", encoding="utf-8") as stream:
+        data = json.load(stream)
+    if isinstance(data, Mapping):
+        cookies = data.get("cookies", [])
+    else:
+        cookies = data
+    if not isinstance(cookies, list):  # pragma: no cover - data validation
+        raise ValueError("Cookies file must contain a list of cookies")
+    return cookies
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Автора24 bidding bot")
+    parser.add_argument(
+        "--account",
+        action="append",
+        metavar="NAME=COOKIES",
+        help="Account name and path to cookies JSON file (name=/path/to/cookies.json)",
+    )
+    parser.add_argument("--base-url", required=True, help="Base URL of the Автора24 platform")
+    return parser
+
+
+def parse_accounts(entries: Iterable[str], base_url: str) -> List[AccountConfig]:
+    configs: List[AccountConfig] = []
+    for entry in entries:
+        if "=" not in entry:
+            raise ValueError("--account must be in NAME=COOKIES_PATH format")
+        name, cookies_path = entry.split("=", 1)
+        cookies = load_cookies(Path(cookies_path))
+        configs.append(AccountConfig(name=name, base_url=base_url, cookies=cookies))
+    return configs
+
+
+def install_shutdown_hooks(workers: Iterable[AccountWorker]) -> None:
+    def _shutdown_handler(signum, frame):  # pragma: no cover - signal handler
+        LOGGER.info("Received signal %s, shutting down", signum)
+        for worker in workers:
+            with contextlib.suppress(Exception):
+                worker.close()
+        sys.exit(0)
+
+    for signame in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(signame, _shutdown_handler)
+
+
+def main(argv: Sequence[str] | None = None, scheduler: Scheduler | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.account:
+        parser.error("At least one --account must be provided")
+
+    if scheduler is None:
+        scheduler = _LoggingScheduler()
+
+    configs = parse_accounts(args.account, args.base_url)
+    workers = [create_account_worker(config, scheduler) for config in configs]
+    install_shutdown_hooks(workers)
+
+    LOGGER.info("Workers initialised: %s", ", ".join(config.name for config in configs))
+    parser.print_help()
+    return 0
+
+
+class _LoggingScheduler:
+    """Fallback scheduler used when none is provided."""
+
+    def schedule(self, payload: Mapping[str, object]) -> None:  # pragma: no cover - simple logger
+        LOGGER.info("Scheduled follow-up for %s", payload)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    sys.exit(main())

--- a/src/avtor24_bot/worker.py
+++ b/src/avtor24_bot/worker.py
@@ -1,0 +1,49 @@
+"""Worker primitives for interacting with Автора24 orders."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+from .browser_bid import BidStatus, BrowserBidExecutor
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Scheduler(Protocol):
+    """Minimal protocol for objects that can schedule follow-up jobs."""
+
+    def schedule(self, payload: Mapping[str, Any]) -> None:  # pragma: no cover - structural protocol
+        """Schedule another job for processing."""
+
+
+@dataclass
+class AccountWorker:
+    """Processes orders for a single account."""
+
+    scheduler: Scheduler
+    bid_executor: BrowserBidExecutor
+
+    def submit_bid(self, order: Mapping[str, Any], bid: float, message: str) -> BidStatus:
+        """Submit a bid and propagate the workflow depending on the result."""
+
+        LOGGER.debug("Submitting bid for order %s", order.get("id") or order.get("order_id"))
+        status = self.bid_executor.place_bid(order, bid, message)
+        if status is BidStatus.SUCCESS:
+            LOGGER.info("Bid submitted successfully, scheduling follow-up")
+            self.scheduler.schedule(order)
+        elif status is BidStatus.CAPTCHA_REQUIRED:
+            LOGGER.warning("Captcha required for order %s", order)
+        elif status is BidStatus.MODAL_TIMEOUT:
+            LOGGER.warning("Timeout while waiting for confirmation modal for order %s", order)
+        else:
+            LOGGER.error("Bid submission failed for order %s", order)
+        return status
+
+    def close(self) -> None:
+        """Release resources held by the worker."""
+
+        self.bid_executor.close()
+
+
+__all__ = ["AccountWorker", "Scheduler"]


### PR DESCRIPTION
## Summary
- implement a Playwright-based BrowserBidExecutor that authenticates via cookies and automates the offer form
- update the account worker to use the new executor interface and forward success to the scheduler
- extend the CLI to create per-account executors with dedicated profiles and graceful shutdown hooks

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d7e164df008332bd99ee06dff988b5